### PR TITLE
WIP: Add support for older git versions

### DIFF
--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -1,0 +1,23 @@
+name: Distros Check
+
+on: [push]
+
+jobs:
+
+  distros:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install requirements
+      run: |
+        export DEBIAN_FRONTEND="noninteractive" && \
+        sudo -E apt-get update && \
+        sudo -E apt-get install -y tox
+    - name: Test centos:8
+      run: TEST_IMAGE=pycontribs/centos:8 /usr/bin/tox -e distro
+    - name: Test centos:7
+      run: TEST_IMAGE=pycontribs/centos:7 /usr/bin/tox -e distro
+    - name: Test ubuntu:latest
+      run: TEST_IMAGE=pycontribs/ubuntu:latest /usr/bin/tox -e distro

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+ARG TEST_IMAGE=pycontribs/centos:7
+
+FROM $TEST_IMAGE
+# pycontribs just contains pre-installed python
+ADD . /app
+WORKDIR /app
+
+RUN PY=`command -v python3 python 2>/dev/null | head -1` && \
+$PY --version && \
+$PY -m pip install . && \
+$PY -m pre_commit run --color=always -v -a || \
+{ cat /root/.cache/pre-commit/pre-commit.log; exit 1; }

--- a/pre_commit/store.py
+++ b/pre_commit/store.py
@@ -140,6 +140,12 @@ class Store(object):
         """Perform a complete clone of a repository and its submodules """
 
         git_cmd('fetch', 'origin', '--tags')
+        # old git versions like 1.8.1 would fail to pull newer revisions, so
+        # if we fail to find the revision, we do a full pull.
+        x = git_cmd('git', 'cat-file', '-t', ref)
+        print(x)
+        git_cmd('git', 'pull')
+
         git_cmd('checkout', ref)
         git_cmd('submodule', 'update', '--init', '--recursive')
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py36,py37,pypy,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt
-passenv = HOME LOCALAPPDATA RUSTUP_HOME
+passenv = DOCKER_HOST HOME LOCALAPPDATA RUSTUP_HOME
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
@@ -14,6 +14,16 @@ commands =
 skip_install = true
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:distro]
+description = Tests pre-commit basic functionality on specific platform
+setenv =
+    TEST_IMAGE={env:TEST_IMAGE:pycontribs/centos:7}
+commands =
+    docker pull {env:TEST_IMAGE}
+    docker build --build-arg TEST_IMAGE={env:TEST_IMAGE} .
+whitelist_externals =
+    docker
 
 [pep8]
 ignore = E265,E501,W504


### PR DESCRIPTION
Implements a fallback mecanisms that pull all revisions if initial
revision is not found in repository.

Adds *optional* job that performs a minimal platform compatibility
testing.

#Fixes: 1206 gitlab clonning
#Fixes: 1211 reference is not a tree
#Fixes: 1213 testing on centos-7